### PR TITLE
Remove complex at-eval-try support

### DIFF
--- a/examples/tests.jl
+++ b/examples/tests.jl
@@ -227,7 +227,7 @@ Text(output)
 
 # Demo:
 
-@testset_error try
+@testset_error "@testset_error" try
     if true
         error(1)
     end
@@ -366,7 +366,7 @@ output = decode_output("""
 
 # Demo:
 
-@testset_error try
+@testset_error "@testset_error + @dedent + @eval" try
     @dedent @eval begin
         @inline begin end
     end

--- a/examples/tests.jl
+++ b/examples/tests.jl
@@ -352,7 +352,7 @@ Text(LiterateTest.preprocess(input))
 # Note that `@eval` is in between `try` and `begin` in the first line.
 
 output = decode_output("""
-    |err = try @eval begin # hide|
+    |err = try # hide|
     |@eval begin # hide|
     |@inline begin end|
     |end # hide|

--- a/examples/tests.jl
+++ b/examples/tests.jl
@@ -209,11 +209,11 @@ Text(LiterateTest.preprocess(input))
 #-
 
 output = decode_output("""
-    |err = try  begin # hide|
+    |err = try # hide|
     |if true|
     |    error(1)|
     |end|
-    |end catch _err; _err; end # hide|
+    |catch _err; _err; end # hide|
     |print(stdout, "ERROR: ") # hide|
     |showerror(stdout, err) # hide|
     |#-|

--- a/examples/tests.jl
+++ b/examples/tests.jl
@@ -349,7 +349,7 @@ input = """
 
 Text(LiterateTest.preprocess(input))
 
-# Note that `@eval` is in between `try` and `begin` in the first line.
+# Note that all lines except `@inline begin end` ends with `# hide`.
 
 output = decode_output("""
     |err = try # hide|

--- a/src/LiterateTest.jl
+++ b/src/LiterateTest.jl
@@ -113,7 +113,7 @@ function preprocess(original::AbstractString)
                 print(io, THROWING_FOOTER)
                 consume_until_end(source)
             end
-        elseif (m = match(r"^@testset_error +((.*?) +)?try$", ln)) !== nothing
+        elseif (m = match(r"^@testset_error .*try$", ln)) !== nothing
             print(io, THROWING_HEADER)
             # TODO: less manual recursive processing
             inner = sprint() do io
@@ -292,12 +292,9 @@ macro testset_error(expr)
     return esc(_testset_error(__source__, __module__, nothing, expr))
 end
 
-# TODO: Support `@testset_error(label, expr)` in `preprocess`.
-#=
 macro testset_error(label, expr)
     return esc(_testset_error(__source__, __module__, label, expr))
 end
-=#
 
 function _testset_error(__source__, __module__, label, expr)
     error_symbol = nothing

--- a/src/LiterateTest.jl
+++ b/src/LiterateTest.jl
@@ -114,10 +114,14 @@ function preprocess(original::AbstractString)
                 consume_until_end(source)
             end
         elseif (m = match(r"^@testset_error +((.*?) +)?try$", ln)) !== nothing
-            println(io, "err = try ", something(m[2], ""), " begin # hide")
-            print_deindent_until(io, source) do ln
-                startswith(ln, "catch ")
+            print(io, THROWING_HEADER)
+            # TODO: less manual recursive processing
+            inner = sprint() do io
+                print_deindent_until(io, source) do ln
+                    startswith(ln, "catch ")
+                end
             end
+            print(io, preprocess(inner))
             print(io, "end ", THROWING_FOOTER)
             consume_until_end(source)
         #! format: off

--- a/src/LiterateTest.jl
+++ b/src/LiterateTest.jl
@@ -122,7 +122,7 @@ function preprocess(original::AbstractString)
                 end
             end
             print(io, preprocess(inner))
-            print(io, "end ", THROWING_FOOTER)
+            print(io, THROWING_FOOTER)
             consume_until_end(source)
         #! format: off
         #=

--- a/test/test_misc.jl
+++ b/test/test_misc.jl
@@ -43,7 +43,7 @@ end
     end
     @test err isa Exception
     msg = sprint(showerror, err)
-    @test occursin("does not contain `try`-`catch` block", msg)
+    @test occursin("`try`-`catch` block", msg)
 end
 
 end  # module


### PR DESCRIPTION
## Commit Message
Remove complex at-eval-try support (#19)

Remove code handling `@testset_error @eval try`.  It is much more
composable to use `@dedent @eval`.